### PR TITLE
Make mypy check all modules

### DIFF
--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -20,7 +20,7 @@ import enum
 import json
 import os
 import pathlib
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from tensorflow import Tensor, signal, keras, saved_model
 import numpy as np
@@ -330,7 +330,7 @@ def predict(
 
 
 def predict_and_save(
-    audio_path_list: List[Union[pathlib.Path, str]],
+    audio_path_list: Sequence[Union[pathlib.Path, str]],
     output_directory: Union[pathlib.Path, str],
     save_midi: bool,
     sonify_midi: bool,

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = flake8
 basepython = python3.8
 deps =
     mypy
-commands = mypy basic_pitch/layers tests --strict --ignore-missing-imports --allow-subclassing-any
+commands = mypy basic_pitch tests --strict --ignore-missing-imports --allow-subclassing-any
 
 [flake8]
 show-source = true


### PR DESCRIPTION
This PR fixes a thing in `tox.ini` where tox was configured for mypy to only check `tests` and the `basic_pitch/layers` module. Updated to check all of `tests` and `basic_pitch`.
Also fixing a type issue in `basic_pitch/inference`