### PR TITLE
Parameterize sampling rate for sonify_midi

### DIFF
--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -344,7 +344,7 @@ def predict_and_save(
     model_path: Union[pathlib.Path, str] = ICASSP_2022_MODEL_PATH,
     onset_threshold: float = 0.5,
     frame_threshold: float = 0.3,
-    sonify_midi_sr: int = 44100,
+    sonification_samplerate: int = 44100,
     minimum_note_length: float = 58,
     minimum_frequency: Optional[float] = None,
     maximum_frequency: Optional[float] = None,
@@ -364,6 +364,7 @@ def predict_and_save(
         model_path: Path to load the Keras saved model from. Can be local or on GCS.
         onset_threshold: Minimum energy required for an onset to be considered present.
         frame_threshold: Minimum energy requirement for a frame to be considered present.
+        sonification_samplerate: Sample rate for rendering audio from MIDI.
         minimum_note_length: The minimum allowed note length in frames.
         minimum_freq: Minimum allowed output frequency, in Hz. If None, all frequencies are used.
         maximum_freq: Maximum allowed output frequency, in Hz. If None, all frequencies are used.
@@ -408,7 +409,7 @@ def predict_and_save(
             if sonify_midi:
                 midi_sonify_path = build_output_path(audio_path, output_directory, OutputExtensions.MIDI_SONIFICATION)
                 try:
-                    infer.sonify_midi(midi_data, midi_sonify_path, sr=sonify_midi_sr)
+                    infer.sonify_midi(midi_data, midi_sonify_path, sr=sonification_samplerate)
                     file_saved_confirmation(OutputExtensions.MIDI_SONIFICATION.name, midi_sonify_path)
                 except Exception:
                     failed_to_save(OutputExtensions.MIDI_SONIFICATION.name, midi_sonify_path)

--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -344,6 +344,7 @@ def predict_and_save(
     model_path: Union[pathlib.Path, str] = ICASSP_2022_MODEL_PATH,
     onset_threshold: float = 0.5,
     frame_threshold: float = 0.3,
+    sonify_midi_sr: int = 44100,
     minimum_note_length: float = 58,
     minimum_frequency: Optional[float] = None,
     maximum_frequency: Optional[float] = None,
@@ -407,7 +408,7 @@ def predict_and_save(
             if sonify_midi:
                 midi_sonify_path = build_output_path(audio_path, output_directory, OutputExtensions.MIDI_SONIFICATION)
                 try:
-                    infer.sonify_midi(midi_data, midi_sonify_path)
+                    infer.sonify_midi(midi_data, midi_sonify_path, sr=sonify_midi_sr)
                     file_saved_confirmation(OutputExtensions.MIDI_SONIFICATION.name, midi_sonify_path)
                 except Exception:
                     failed_to_save(OutputExtensions.MIDI_SONIFICATION.name, midi_sonify_path)

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -107,8 +107,8 @@ def model_output_to_notes(
 
 
 def sonify_midi(
-    midi: pretty_midi.PrettyMIDI, 
-    save_path: Union[pathlib.Path, str], 
+    midi: pretty_midi.PrettyMIDI,
+    save_path: Union[pathlib.Path, str],
     sr: Optional[int] = 44100
 ) -> None:
     """Sonify a pretty_midi midi object and save to a file.

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -106,15 +106,16 @@ def model_output_to_notes(
     return note_events_to_midi(estimated_notes_time_seconds, multiple_pitch_bends), estimated_notes_time_seconds
 
 
-def sonify_midi(midi: pretty_midi.PrettyMIDI, save_path: Union[pathlib.Path, str]) -> None:
+def sonify_midi(midi: pretty_midi.PrettyMIDI, save_path: Union[pathlib.Path, str], sr: Optional[int] = 44100
+) -> None:
     """Sonify a pretty_midi midi object and save to a file.
 
     Args:
         midi: A pretty_midi.PrettyMIDI object that will be sonified.
         save_path: Where to save the sonified midi.
     """
-    y = midi.synthesize(44100)
-    wavfile.write(save_path, 44100, y)
+    y = midi.synthesize(sr)
+    wavfile.write(save_path, sr, y)
 
 
 def sonify_salience(

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -113,6 +113,7 @@ def sonify_midi(midi: pretty_midi.PrettyMIDI, save_path: Union[pathlib.Path, str
     Args:
         midi: A pretty_midi.PrettyMIDI object that will be sonified.
         save_path: Where to save the sonified midi.
+        sr: Sample rate for rendering audio from midi.
     """
     y = midi.synthesize(sr)
     wavfile.write(save_path, sr, y)

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -106,7 +106,10 @@ def model_output_to_notes(
     return note_events_to_midi(estimated_notes_time_seconds, multiple_pitch_bends), estimated_notes_time_seconds
 
 
-def sonify_midi(midi: pretty_midi.PrettyMIDI, save_path: Union[pathlib.Path, str], sr: Optional[int] = 44100
+def sonify_midi(
+    midi: pretty_midi.PrettyMIDI, 
+    save_path: Union[pathlib.Path, str], 
+    sr: Optional[int] = 44100
 ) -> None:
     """Sonify a pretty_midi midi object and save to a file.
 


### PR DESCRIPTION
Allow sampling rate in sonify_midi to be parameterizable when calling predict_and_save, instead of a hard-coded 44100 Hz.