### PR TITLE
Bump version: 0.0.1 → 0.1.0

### DIFF
--- a/basic_pitch/__init__.py
+++ b/basic_pitch/__init__.py
@@ -18,7 +18,7 @@
 import pathlib
 
 __author__ = "Spotify"
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 __email__ = "basic-pitch@spotify.com"
 __demowebsite__ = "https://basicpitch.io"
 __description__ = "Basic Pitch, a lightweight yet powerful audio-to-MIDI converter with pitch bend detection."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+
 [metadata]
 name = basic-pitch
 version = attr: basic_pitch.__version__
@@ -53,12 +58,6 @@ dev =
     bump2version>=1.0.1
     mypy
     tox
-
-
-[bumpversion]
-current_version = 0.0.1
-commit = True
-tag = True
 
 [bumpversion:file:basic_pitch/__init__.py]
 


### PR DESCRIPTION
Bump to 0.1.0. We will bump to 1.0.0 once training and evaluation code are added.

Not sure why but `bumpversion` decided to rewrite code in an awkwardly. 