### PR TITLE
Expose tracebacks

### DIFF
--- a/basic_pitch/commandline_printing.py
+++ b/basic_pitch/commandline_printing.py
@@ -15,14 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import os
 import pathlib
-import sys
 import threading
-import time
 from contextlib import contextmanager
-from typing import Iterator, Optional, Union
+from typing import Iterator, Union
 
 TF_LOG_LEVEL_KEY = "TF_CPP_MIN_LOG_LEVEL"
 TF_LOG_LEVEL_NO_WARNINGS_VALUE = "3"
@@ -76,59 +73,3 @@ def no_tf_warnings() -> Iterator[None]:
     os.environ[TF_LOG_LEVEL_KEY] = TF_LOG_LEVEL_NO_WARNINGS_VALUE
     yield
     os.environ[TF_LOG_LEVEL_KEY] = tf_logging_level
-
-
-@contextmanager
-def entertaining_waiting(operation_name: Optional[str] = None) -> Iterator[None]:
-    """
-    Display a jazzy loading animation in the commandline for the duration of this context
-
-    Args:
-        operation_name: the name of the operation contained in this context to be displayed in
-        the commandline
-    """
-    if operation_name is None:
-        operation_name = f"Running Command: '{inspect.stack()[2].function}'"
-
-    loading = True
-    loading_states = ["🥁", "🎷", "🎸", "🎻", "🎹", "🪘", "🪗", "🎺", "🪕"]
-    blank_message = " " * (len(loading_states) * 2 + len(operation_name))
-
-    def animate() -> None:
-        emoji_index = 0
-        while loading:
-            if emoji_index >= len(loading_states):
-                emoji_index = 0
-                loading_message = blank_message
-            else:
-                loading_message = "".join(loading_states[0:emoji_index])
-
-            s_flush()
-            s_print(f"\r{operation_name}...  " + loading_message)
-            emoji_index += 1
-            time.sleep(0.3)
-
-    t = threading.Thread(target=animate)
-    t.start()
-
-    yield
-    loading = False
-
-
-def s_print(msg: str) -> None:
-    """
-    Thread safe print function
-
-    Args:
-        msg: the text to be printed to stdout
-    """
-    with s_print_lock:
-        sys.stdout.write(msg)
-
-
-def s_flush() -> None:
-    """
-    Thread safe flush function
-    """
-    with s_print_lock:
-        sys.stdout.flush()

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -106,11 +106,7 @@ def model_output_to_notes(
     return note_events_to_midi(estimated_notes_time_seconds, multiple_pitch_bends), estimated_notes_time_seconds
 
 
-def sonify_midi(
-    midi: pretty_midi.PrettyMIDI,
-    save_path: Union[pathlib.Path, str],
-    sr: Optional[int] = 44100
-) -> None:
+def sonify_midi(midi: pretty_midi.PrettyMIDI, save_path: Union[pathlib.Path, str], sr: Optional[int] = 44100) -> None:
     """Sonify a pretty_midi midi object and save to a file.
 
     Args:

--- a/basic_pitch/predict.py
+++ b/basic_pitch/predict.py
@@ -93,6 +93,12 @@ def main() -> None:
         help="Allow overlapping notes in midi file to have pitch bends. Note: this will map each "
         "pitch to its own instrument",
     )
+    parser.add_argument(
+        "--sonification-samplerate",
+        type=int,
+        default=44100,
+        help="The samplerate for sonified audio files.",
+    )
     parser.add_argument("--debug-file", default=None, help="Optional file for debug output for inference.")
     parser.add_argument("--no-melodia", default=False, action="store_true", help="Skip the melodia trick.")
     args = parser.parse_args()
@@ -101,9 +107,11 @@ def main() -> None:
     print("✨✨✨✨✨✨✨✨✨")
     print("✨ Basic Pitch  ✨")
     print("✨✨✨✨✨✨✨✨✨")
+    print("")
 
     # tensorflow is very slow to import
     # this import is here so that the help messages print faster
+    print("Importing Tensorflow (this may take a few seconds)...")
     from basic_pitch.inference import predict_and_save, verify_output_dir, verify_input_path
 
     output_dir = pathlib.Path(args.output_dir)
@@ -129,6 +137,7 @@ def main() -> None:
         args.multiple_pitch_bends,
         not args.no_melodia,
         pathlib.Path(args.debug_file) if args.debug_file else None,
+        args.sonification_samplerate,
     )
 
     print("\n✨ Done ✨\n")

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands = mypy basic_pitch tests --strict --ignore-missing-imports --allow-subc
 show-source = true
 max-line-length = 120
 exclude = .venv,.tox,.git,dist,doc,*.egg,build
-ignore = E203,E731,W503,
+ignore = E203,E731,W503,E231
 
 [pytest]
 addopts = -v


### PR DESCRIPTION
Errors in the predict script currently get swallowed by the pretty printing we do. This re-exposes traceback errors if they occur.

There was also a little bug introduced by #20 , which added a function argument that wasn't passed in by the commandline script - this patches it.