### PR TITLE
Add midi tempo CLI argument

### DIFF
--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -271,6 +271,7 @@ def predict(
     multiple_pitch_bends: bool = False,
     melodia_trick: bool = True,
     debug_file: Optional[pathlib.Path] = None,
+    midi_tempo: float = 120,
 ) -> Tuple[Dict[str, np.array], pretty_midi.PrettyMIDI, List[Tuple[float, float, int, float, Optional[List[int]]]],]:
     """Run a single prediction.
 
@@ -311,6 +312,7 @@ def predict(
             max_freq=maximum_frequency,
             multiple_pitch_bends=multiple_pitch_bends,
             melodia_trick=melodia_trick,
+            midi_tempo=midi_tempo,
         )
 
     if debug_file:
@@ -357,6 +359,7 @@ def predict_and_save(
     melodia_trick: bool = True,
     debug_file: Optional[pathlib.Path] = None,
     sonification_samplerate: int = 44100,
+    midi_tempo: float = 120,
 ) -> None:
     """Make a prediction and save the results to file.
 
@@ -394,6 +397,7 @@ def predict_and_save(
                 multiple_pitch_bends,
                 melodia_trick,
                 debug_file,
+                midi_tempo,
             )
 
             if save_model_outputs:

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -54,6 +54,7 @@ def model_output_to_notes(
     include_pitch_bends: bool = True,
     multiple_pitch_bends: bool = False,
     melodia_trick: bool = True,
+    midi_tempo: float = 120,
 ) -> Tuple[pretty_midi.PrettyMIDI, List[Tuple[float, float, int, float, Optional[List[int]]]]]:
     """Convert model output to MIDI
 
@@ -103,7 +104,7 @@ def model_output_to_notes(
         (times_s[note[0]], times_s[note[1]], note[2], note[3], note[4]) for note in estimated_notes_with_pitch_bend
     ]
 
-    return note_events_to_midi(estimated_notes_time_seconds, multiple_pitch_bends), estimated_notes_time_seconds
+    return note_events_to_midi(estimated_notes_time_seconds, multiple_pitch_bends, midi_tempo), estimated_notes_time_seconds
 
 
 def sonify_midi(midi: pretty_midi.PrettyMIDI, save_path: Union[pathlib.Path, str], sr: Optional[int] = 44100) -> None:
@@ -212,6 +213,7 @@ def get_pitch_bends(
 def note_events_to_midi(
     note_events_with_pitch_bends: List[Tuple[float, float, int, float, Optional[List[int]]]],
     multiple_pitch_bends: bool = False,
+    midi_tempo: float = 120,
 ) -> pretty_midi.PrettyMIDI:
     """Create a pretty_midi object from note events
 
@@ -226,7 +228,7 @@ def note_events_to_midi(
         pretty_midi.PrettyMIDI() object
 
     """
-    mid = pretty_midi.PrettyMIDI()
+    mid = pretty_midi.PrettyMIDI(initial_tempo=midi_tempo)
     if not multiple_pitch_bends:
         note_events_with_pitch_bends = drop_overlapping_pitch_bends(note_events_with_pitch_bends)
 

--- a/basic_pitch/predict.py
+++ b/basic_pitch/predict.py
@@ -99,6 +99,12 @@ def main() -> None:
         default=44100,
         help="The samplerate for sonified audio files.",
     )
+    parser.add_argument(
+        "--midi-tempo",
+        type=float,
+        default=120,
+        help="The tempo for the midi file.",
+    )
     parser.add_argument("--debug-file", default=None, help="Optional file for debug output for inference.")
     parser.add_argument("--no-melodia", default=False, action="store_true", help="Skip the melodia trick.")
     args = parser.parse_args()
@@ -138,6 +144,7 @@ def main() -> None:
         not args.no_melodia,
         pathlib.Path(args.debug_file) if args.debug_file else None,
         args.sonification_samplerate,
+        args.midi_tempo,
     )
 
     print("\n✨ Done ✨\n")


### PR DESCRIPTION
# Why

Resolves issue #40 requesting a CLI option of specifying the tempo of the created MIDI file.

This is my first contribution! Unsure if:

- I should add some tests
- The midi tempo is set in [the correct way](https://github.com/spotify/basic-pitch/compare/main...LukasGardberg:basic-pitch:feature-branch#diff-ce098c38843d8c4c8ad03c2ce0105ed308a6a88dc4c505dff0de6ef4a40e9e24R231)

Would happily get some input :)

## What is changing

You are now able to use an option in the CLI to specify the tempo of the created midi file 

## Example

```
basic-pitch <output-directory> <input-audio-path> --midi-tempo 75
```
