### PR TITLE
Fix M1 MacOS platform dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,8 @@ install_requires =
     pretty_midi>=0.2.9
     resampy>=0.2.2
     scipy>=1.4.1
-    tensorflow>=2.4.1,<2.10; platform.machine != 'arm64'
-    tensorflow-macos>=2.4.1,<2.10; platform.machine == 'arm64'
+    tensorflow>=2.4.1,<2.10; platform_machine != 'arm64'
+    tensorflow-macos>=2.4.1,<2.10; platform_machine == 'arm64'
     typing_extensions
 
 [options.entry_points]


### PR DESCRIPTION
https://github.com/spotify/basic-pitch/commit/468dde2a49174659c23a5669fb84c7a7f74d55a5 attempted to provide per-platform dependencies in the `setup.cfg` file, but it didn't work for me. 

A quick check of https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#platform-specific-dependencies (or the PEP reference for more info https://peps.python.org/pep-0508/) showed that the variable should be should be `"platform_machine"` rather than `"platform.machine"`.