### PR TITLE
Add numpy version specification 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
     tensorflow-macos>=2.4.1,<2.10; platform_machine == 'arm64'
     typing_extensions
 
-
 [options.entry_points]
 console_scripts =
     basic-pitch = basic_pitch.predict:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,13 +35,14 @@ include_package_data = True
 install_requires =
     librosa>=0.8.0
     mir_eval>=0.6
+    numpy<1.24,>=1.18
     pretty_midi>=0.2.9
     resampy>=0.2.2
     scipy>=1.4.1
     tensorflow>=2.4.1,<2.10; platform_machine != 'arm64'
     tensorflow-macos>=2.4.1,<2.10; platform_machine == 'arm64'
     typing_extensions
-    numpy<1.24,>=1.18
+
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     tensorflow>=2.4.1,<2.10; platform_machine != 'arm64'
     tensorflow-macos>=2.4.1,<2.10; platform_machine == 'arm64'
     typing_extensions
+    numpy<1.24,>=1.18
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
When I run `python3 setup.py install`, I get this error `error: numpy 1.24.1 is installed but numpy<1.24,>=1.18 is required by {'numba'}`. This PR adds this specific range of numpy to the setup config. This allows `python3 setup.py install` to run successfully. 