### PR TITLE
Update README.md to include Mac M1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ To update Basic Pitch to the latest version, add `--upgrade` to the above comman
 
 #### Compatible Environments:
 - MacOS, Windows and Ubuntu operating systems
-- Python versions 3.7, 3.8, 3.9
+- Python versions 3.7, 3.8, 3.9, 3.10
+- **For Mac M1 hardware, we currently only support python version 3.10. Otherwise, we suggest using a virtual machine.**
 
 
 ## Usage


### PR DESCRIPTION
Add line in README under compatible environments:

For Mac M1 hardware, we currently only support python version 3.10. Otherwise, we suggest using a virtual machine.

