### PR TITLE
Allow using newer TensorFlow versions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ install_requires =
 	pretty_midi>=0.2.9
 	resampy>=0.2.2
 	scipy>=1.4.1
-	tensorflow>=2.4.1,<2.12; platform_machine != 'arm64'
-	tensorflow-macos>=2.4.1,<2.12; platform_machine == 'arm64'
+	tensorflow>=2.4.1; platform_machine != 'arm64'
+	tensorflow-macos>=2.4.1; platform_machine == 'arm64'
 	typing_extensions
 
 [options.entry_points]


### PR DESCRIPTION
`tensorflow==2.12` has been out since March, and `2.13` will be released soon; no need for us to artificially cap our TF version.