### PR TITLE
Fix Inconsistent Minimum Note Length

### DIFF
--- a/basic_pitch/__init__.py
+++ b/basic_pitch/__init__.py
@@ -18,7 +18,7 @@
 import pathlib
 
 __author__ = "Spotify"
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 __email__ = "basic-pitch@spotify.com"
 __demowebsite__ = "https://basicpitch.io"
 __description__ = "Basic Pitch, a lightweight yet powerful audio-to-MIDI converter with pitch bend detection."

--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -117,7 +117,6 @@ def unwrap_output(output: Tensor, audio_original_length: int, n_overlapping_fram
     output_shape = raw_output.shape
     n_output_frames_original = int(np.floor(audio_original_length * (ANNOTATIONS_FPS / AUDIO_SAMPLE_RATE)))
     unwrapped_output = raw_output.reshape(output_shape[0] * output_shape[1], output_shape[2])
-    print("unwrapped_output:\n",unwrapped_output[:n_output_frames_original, :])
     return unwrapped_output[:n_output_frames_original, :]  # trim to original audio length
 
 

--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -117,6 +117,7 @@ def unwrap_output(output: Tensor, audio_original_length: int, n_overlapping_fram
     output_shape = raw_output.shape
     n_output_frames_original = int(np.floor(audio_original_length * (ANNOTATIONS_FPS / AUDIO_SAMPLE_RATE)))
     unwrapped_output = raw_output.reshape(output_shape[0] * output_shape[1], output_shape[2])
+    print("unwrapped_output:\n",unwrapped_output[:n_output_frames_original, :])
     return unwrapped_output[:n_output_frames_original, :]  # trim to original audio length
 
 
@@ -351,7 +352,7 @@ def predict_and_save(
     model_path: Union[pathlib.Path, str] = ICASSP_2022_MODEL_PATH,
     onset_threshold: float = 0.5,
     frame_threshold: float = 0.3,
-    minimum_note_length: float = 58,
+    minimum_note_length: float = 127.70,
     minimum_frequency: Optional[float] = None,
     maximum_frequency: Optional[float] = None,
     multiple_pitch_bends: bool = False,

--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -373,7 +373,7 @@ def predict_and_save(
         model_path: Path to load the Keras saved model from. Can be local or on GCS.
         onset_threshold: Minimum energy required for an onset to be considered present.
         frame_threshold: Minimum energy requirement for a frame to be considered present.
-        minimum_note_length: The minimum allowed note length in frames.
+        minimum_note_length: The minimum allowed note length in milliseconds.
         minimum_freq: Minimum allowed output frequency, in Hz. If None, all frequencies are used.
         maximum_freq: Maximum allowed output frequency, in Hz. If None, all frequencies are used.
         multiple_pitch_bends: If True, allow overlapping notes in midi file to have pitch bends.

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -494,5 +494,5 @@ def output_to_notes_polyphonic(
                     amplitude,
                 )
             )
-    
+
     return note_events

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -396,7 +396,6 @@ def output_to_notes_polyphonic(
     # loop over onsets
     note_events = []
     for note_start_idx, freq_idx in zip(onset_time_idx, onset_freq_idx):
-        print("freq_idx: ", freq_idx)
         # if we're too close to the end of the audio, continue
         if note_start_idx >= n_frames - 1:
             continue
@@ -495,6 +494,5 @@ def output_to_notes_polyphonic(
                     amplitude,
                 )
             )
-    print(note_events)
     
     return note_events

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -48,7 +48,7 @@ def model_output_to_notes(
     onset_thresh: float,
     frame_thresh: float,
     infer_onsets: bool = True,
-    min_note_len: int = 5,
+    min_note_len: int = 11,
     min_freq: Optional[float] = None,
     max_freq: Optional[float] = None,
     include_pitch_bends: bool = True,
@@ -396,6 +396,7 @@ def output_to_notes_polyphonic(
     # loop over onsets
     note_events = []
     for note_start_idx, freq_idx in zip(onset_time_idx, onset_freq_idx):
+        print("freq_idx: ", freq_idx)
         # if we're too close to the end of the audio, continue
         if note_start_idx >= n_frames - 1:
             continue
@@ -494,5 +495,6 @@ def output_to_notes_polyphonic(
                     amplitude,
                 )
             )
-
+    print(note_events)
+    
     return note_events

--- a/basic_pitch/predict.py
+++ b/basic_pitch/predict.py
@@ -73,7 +73,7 @@ def main() -> None:
     parser.add_argument(
         "--minimum-note-length",
         type=float,
-        default=58,
+        default=127.70,
         help="The minimum allowed note length, in miliseconds.",
     )
     parser.add_argument(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.6
+current_version = 0.3.0
 commit = True
 tag = True
 


### PR DESCRIPTION
Addressing this issue: #93 

This PR fixes all inconsistent minimum note lengths to be 127.70 ms ( 11 frames)