### PR TITLE
Default predict() to the default model path from __init__.py.

### DIFF
--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -24,7 +24,7 @@ import pathlib
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 
-from basic_pitch import CT_PRESENT, ONNX_PRESENT, TF_PRESENT, TFLITE_PRESENT
+from basic_pitch import CT_PRESENT, ICASSP_2022_MODEL_PATH, ONNX_PRESENT, TF_PRESENT, TFLITE_PRESENT
 
 try:
     import tensorflow as tf
@@ -413,7 +413,7 @@ def save_note_events(
 
 def predict(
     audio_path: Union[pathlib.Path, str],
-    model_or_model_path: Union[Model, pathlib.Path, str],
+    model_or_model_path: Union[Model, pathlib.Path, str] = ICASSP_2022_MODEL_PATH,
     onset_threshold: float = 0.5,
     frame_threshold: float = 0.3,
     minimum_note_length: float = 127.70,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "basic-pitch"
-version = "0.3.1"
+version = "0.3.2"
 description = "Basic Pitch, a lightweight yet powerful audio-to-MIDI converter with pitch bend detection."
 readme = "README.md"
 keywords = []


### PR DESCRIPTION
Per #121 , looks like the README.md says that predict doesn't require a second argument. To match the README, I'm making the default model the platform-specific model path one we detect in `__init__.py`. I believe this was intended, but didn't make it into the original 0.3.0 release.