### PR TITLE
use cuda with onnx if available

### DIFF
--- a/basic_pitch/inference.py
+++ b/basic_pitch/inference.py
@@ -129,7 +129,10 @@ class Model:
             present.append("ONNX")
             try:
                 self.model_type = Model.MODEL_TYPES.ONNX
-                self.model = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+                providers = ["CPUExecutionProvider"]
+                if "CUDAExecutionProvider" in ort.get_available_providers():
+                    providers.insert(0, "CUDAExecutionProvider")
+                self.model = ort.InferenceSession(str(model_path), providers=providers)
                 return
             except Exception as e:
                 if str(model_path).endswith(".onnx"):


### PR DESCRIPTION
Resolves #145 

Here, we check if CUDA provider is available, and if so, we prepend it to the providers used to initialize the ort session. I believe you'd need `onnxruntime-gpu` installed for this to work properly, so it shouldn't have any effect otherwise.

Can try it out in Colab here: https://gist.github.com/nateraw/3fc03dda5b78f0ca08acb15b9882dfe8

Quick first pass, let me know if there's anything I'm missing 😄 