### PR TITLE
Comment out dead layer code in models.py

### DIFF
--- a/basic_pitch/models.py
+++ b/basic_pitch/models.py
@@ -223,17 +223,20 @@ def model(
             N_FREQ_BINS_CONTOURS,
         )(x)
 
-    # contour layers - fully convolutional
-    x_contours = tfkl.Conv2D(
-        n_filters_contour,
-        CONTOUR_KERNEL_SIZE_1,
-        padding="same",
-        kernel_initializer=_initializer(),
-        kernel_constraint=_kernel_constraint(),
-    )(x)
+    # contour layers - fully convolutional - /!\ commented out as it was unintentionally skipped
+    # when training the model presented in the paper.
+    # TODO: retrain with layer included and replace checkpoints if it yields benefits
+    #
+    # x_contours = tfkl.Conv2D(
+    #     n_filters_contour,
+    #     CONTOUR_KERNEL_SIZE_1,
+    #     padding="same",
+    #     kernel_initializer=_initializer(),
+    #     kernel_constraint=_kernel_constraint(),
+    # )(x)
 
-    x_contours = tfkl.BatchNormalization()(x_contours)
-    x_contours = tfkl.ReLU()(x_contours)
+    # x_contours = tfkl.BatchNormalization()(x_contours)
+    # x_contours = tfkl.ReLU()(x_contours)
 
     x_contours = tfkl.Conv2D(
         CONTOUR_FILTERS_2,


### PR DESCRIPTION
As highlighted in https://github.com/spotify/basic-pitch/issues/21, the first contour layer is unintentionally skipped at the moment.

Given the saved model assets do not contain this layer, we're not adding it back immediately to keep models.py in sync with the current models in use. The code will be commented out until we do a retrain and evaluate if there's any benefits in adding the layer back.